### PR TITLE
fix: sign up race condition meaning first log in fails

### DIFF
--- a/web-app/pages/login.vue
+++ b/web-app/pages/login.vue
@@ -4,7 +4,7 @@
       size="lg"
       :disabled="isSubmitting"
       @click="onLoginClick"
-      v-text="'Login'"
+      v-text="'Login or Sign Up'"
     />
   </section>
 </template>


### PR DESCRIPTION
When a user first provisions there account, their initial log in will sometimes fail with the error "User does not exist." This is because the database trigger to provision the user record has not yet completed (tends to happen when the site hasn't been used in a while as the cloud function needs to "cold start").

This PR adds logic to retry once after 1.5s, which seems to eliminate this error.